### PR TITLE
Andrey Shmelev: "exec" causes "trap" issue on Ubuntu 16.04

### DIFF
--- a/templates/run.erb
+++ b/templates/run.erb
@@ -5,4 +5,4 @@ ulimit -<%=k%> <%=v%>
 <%= "sleep #{@sleep}" if @sleep && @sleep.to_i > 0 %>
 exec 2>&1
 <%= @pre_command if @pre_command %>
-exec <%= "#{@change_user_command} #{@user}" if @user %> <%= @command %>
+<%= "#{@change_user_command} #{@user}" if @user %> <%= @command %>


### PR DESCRIPTION
Tests successfully passed with:
- Ubuntu 16.04
- Ubuntu 14.04
- Centos 7.0.x
